### PR TITLE
Added script that empties itself

### DIFF
--- a/empties
+++ b/empties
@@ -1,0 +1,1 @@
+#!/bin/cp /dev/null


### PR DESCRIPTION
Explanation : copying /dev/null into a file empties it. So this script basically empties itself 

Demo : 

[![asciicast](https://asciinema.org/a/bp766q2gfnqaf5wh38eivda41.png)](https://asciinema.org/a/bp766q2gfnqaf5wh38eivda41)
